### PR TITLE
Ignore prompt for pip

### DIFF
--- a/deploy/deploy.monolith.bash
+++ b/deploy/deploy.monolith.bash
@@ -27,14 +27,9 @@ set -eu
 
 echo
 echo
-echo "Uninstall Brood previous version"
-"${PIP}" uninstall -y brood
-
-echo
-echo
 echo "Updating Python dependencies"
 "${PIP}" install --upgrade pip
-"${PIP}" install -r "${APP_DIR}/requirements.txt"
+"${PIP}" install --exists-action i -r "${APP_DIR}/requirements.txt"
 
 echo
 echo


### PR DESCRIPTION
<!-- Thank you for your contribution. -->
<!-- Filling in the sections below will provide us with some context when we are reviewing your pull request. -->

## Changes

Correct behavior when we ignore prompt from pip when he arguing for previous brood version

## How to test these changes?

In prod

## Related issues

<!-- Is this PR related to any of the issues at https://github.com/orgs/bugout-dev/projects/3 ? -->
<!-- If this PR resolves any of those issues, add a line in the format "Resolves <link to isssue>". -->

<!-- Thanks again! :) -->
